### PR TITLE
smart contract improvements

### DIFF
--- a/contract/contracts/Donation.sol
+++ b/contract/contracts/Donation.sol
@@ -7,10 +7,22 @@ pragma solidity ^0.8.0;
 /// and other users can donate Ether to the image authors.
 contract Donation {
     uint256 public imageCount;
+
+      // Mapping to track whether an image hash has been uploaded
+      mapping(string => bool) private uploadedImageHashes;
+      address private contractOwner;
+
+  // Modifier to check if the sender is the contract owner
+    modifier onlyOwner() {
+        require(msg.sender == contractOwner, "Only contract owner can perform this");
+        _;
+    }
     
     /// @dev Constructor to initialize the image count
     constructor() {
         imageCount = 0;
+        contractOwner = msg.sender;
+
     }
 
     struct Image {
@@ -46,6 +58,11 @@ contract Donation {
         require(bytes(_imgHash).length > 0, "Image hash cannot be empty");
         require(bytes(_description).length > 0, "Description cannot be empty");
         require(msg.sender != address(0), "Invalid sender address");
+        require(!uploadedImageHashes[_imgHash], "Image already uploaded");
+
+        uploadedImageHashes[_imgHash] = true;
+
+
         imageCount++;
         images[imageCount] = Image(
             imageCount,
@@ -56,6 +73,30 @@ contract Donation {
         );
         emit ImageCreated(imageCount, _imgHash, _description, 0, msg.sender);
     }
+
+       // Withdraw accidentally sent funds
+    function withdrawAccidentalFunds() public onlyOwner {
+        uint256 balance = address(this).balance;
+        require(balance > 0, "No Ether to withdraw");
+
+        payable(contractOwner).transfer(balance);
+    }
+
+    function withdrawDonations(uint256 _imageId) public {
+    require(_imageId > 0 && _imageId <= imageCount, "Invalid image ID");
+
+    Image storage _image = images[_imageId];
+    require(msg.sender == _image.author, "Only the image author can withdraw");
+
+    uint256 authorBalance = _image.donationAmount;
+    require(authorBalance > 0, "No donations to withdraw");
+
+    _image.donationAmount = 0; // Reset the author's balance
+    images[_imageId] = _image;
+
+    payable(msg.sender).transfer(authorBalance);
+}
+
 
     /// @notice Donate Ether to the author of an image
     /// @param _id ID of the image to donate to
@@ -69,7 +110,6 @@ contract Donation {
         require(donationAmount > 0, "Donation amount must be greater than 0");
         
         _image.donationAmount += donationAmount; // Update donation amount
-        images[_id] = _image;
         
         // Use "Checks-Effects-Interactions" pattern to mitigate reentrancy
         (bool success, ) = _author.call{value: donationAmount}("");


### PR DESCRIPTION
1- This is redundant. The line Image storage _image = images[_id]; directly references the images mapping. When you modify _image.donationAmount, you're directly updating the mapping. You don't need to reassign it with images[_id] = _image;.

_image.donationAmount += donationAmount; 
images[_id] = _image;

2- Added a check to prevent the same image to be uploaded multiple times 

3- Implemented a  way for the contract owner or authors to withdraw any accidentally sent funds to the contract, apart from the image donation mechanism.

4- In functions like getTotalDonationAmount, changed  view function modifier instead of public